### PR TITLE
Issue #46: Removed local.properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Jun 05 16:41:12 CEST 2020
-sdk.dir=C\:\\Users\\renen\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Fixes #46 

Removed the local.properties file from the project-root as this file contains information specific to the developer. See https://github.com/mobileappdevhm20/team-project-team_6/issues/46 for more info.

